### PR TITLE
fix: enumerate the `BuildMany` extenion method so that entities are seeded into the database #182830

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1 - 2024-10-30
+### Fixed
+- Bug Fix: entities not saved when seeding many using the `IEntitySeed.PerformSeeding` method (#182830).
+
 ## 2.0.0 - 2024-09-24
 ### Added
 - Complete rewrite of the project based on existing need, and lack of uptake on the current project.

--- a/src/Audacia.Seed/EntitySeed.cs
+++ b/src/Audacia.Seed/EntitySeed.cs
@@ -122,7 +122,7 @@ public class EntitySeed<TEntity> : IEntitySeed<TEntity>
 
         if (Options.AmountToCreate > 1)
         {
-            _ = BuildMany(Options.AmountToCreate);
+            _ = BuildMany(Options.AmountToCreate).ToList();
         }
         else
         {

--- a/tests/Audacia.Seed.Tests/EntitySeedTests.cs
+++ b/tests/Audacia.Seed.Tests/EntitySeedTests.cs
@@ -111,6 +111,34 @@ public sealed class EntitySeedTests : IDisposable
         act.Should().ThrowExactly<DataSeedingException>("we should throw an exception if the getter does not access a property on the entity");
     }
 
+    [Fact]
+    public void PerformSeeding_SeedingManyEntities_ManyEntitiesSavedToDatabase()
+    {
+        var entitySeed = new EntitySeed<Booking>();
+        const int amountToCreate = 2;
+        entitySeed.Options.AmountToCreate = amountToCreate;
+
+        entitySeed.PerformSeeding(new EntityFrameworkCoreSeedableRepository(_context));
+        _context.SaveChanges();
+
+        var anyBookingsSeeded = _context.Set<Booking>().Count();
+        anyBookingsSeeded.Should().Be(amountToCreate);
+    }
+
+    [Fact]
+    public void PerformSeeding_SeedingOneEntity_OneEntitySavedToDatabase()
+    {
+        var entitySeed = new EntitySeed<Booking>();
+        const int amountToCreate = 1;
+        entitySeed.Options.AmountToCreate = amountToCreate;
+
+        entitySeed.PerformSeeding(new EntityFrameworkCoreSeedableRepository(_context));
+        _context.SaveChanges();
+
+        var anyBookingsSeeded = _context.Set<Booking>().Count();
+        anyBookingsSeeded.Should().Be(amountToCreate);
+    }
+
     public void Dispose()
     {
         _context.Dispose();


### PR DESCRIPTION


| Action | Done? |
| --- | --- |
| CHANGELOG updated | ✔ |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ✔ |
| README updated | ❌ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |
