### PR TITLE
Clear change tracker when seeding begins (EF Core only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.3 - 2025-02-13
+### Fixed
+- Clear the change tracker when seeding begins to ensure WithNew is respected (#190707).
+- Fix issue where the CHANGELOG & README files were appearing in consuming projects (#188898).
+
 ## 2.0.2 - 2024-11-05
 ### Fixed
 - Bug Fix: don't reload entities after saving them to protect against false-positives in unit tests (#182829).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.3 - 2025-02-13
 ### Fixed
-- Clear the change tracker when seeding begins to ensure WithNew is respected (#190707).
+- EF Core only: Clear the change tracker when seeding begins to ensure WithNew is respected (#190707).
 - Fix issue where the CHANGELOG & README files were appearing in consuming projects (#188898).
 
 ## 2.0.2 - 2024-11-05

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>2.0.2</Version>
+        <Version>2.0.3</Version>
     </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ new BookingSeed().Without(b => b.Name);
 
 ### `WithNew` (single entity)
 Specify that an navigation optional property should be non-null, or override the default behaviour for a mandatory navigation property.
+When using `WithNew`, the library will always seed a new instance of the navigation property. When using this with `SeedMany`, each child will share the same newly-added parent.
+
 #### Set a navigation property without a seed:
 ```csharp
 new BookingSeed().WithNew(b => b.Coupon);

--- a/docs/adr/0001-clear-the-ef-core-change-tracker.md
+++ b/docs/adr/0001-clear-the-ef-core-change-tracker.md
@@ -8,17 +8,19 @@ Date: 2024-11-05
 
 ## Context
 
-NOTE: the entirety of this document applied to EF Core functionality only, and is not the case in the `.EntityFramework` package.
+NOTE: the entirety of this document applies to EF Core functionality only, and is not the case for the `.EntityFramework` package.
 
-When setting up data for a test, an EF Core database context remembers that entity (and any navigation properties it has populated) by persiting it in its change tracker.
+When setting up data for a test, an EF Core database context remembers that entity (and any navigation properties it has populated) by persiting it in its change tracker in-memory.
 
 This means that if you set up data for a test and immediately execute the test target with the same `DbContext` instance, you're executing the test with a non-empty change tracker and therefore you test doesn't have the same clean slate that it does when executing the test target in production.
 
-This can, and has, lead to false positives in our unit tests - meaning the unit test passes when running it, but manually testing the same functionality throws an error. 
+This can, and has, lead to false positives in unit tests - meaning the unit test passes when running it, but manually testing the same functionality throws an error. 
 
 An example of this is when you don't do an explicit `Include` of a navigation property which has been set up in the test. In this scenario, the entity and it's navigation property is in the change tracker. In production it's not, and will null ref.
 
 Previously, we have reloaded (`dbContext.Entry.Reload()`) the entity, but have now removed this as it also reloads the navigation properties, which gives us the same issue as above.
+
+For avoidance of doubt, when using EF Core's in-memory provider for unit tests clearing the change tracker won't help you spot false positives for missing `Include`s. If using a SQL DB, it's recommended you use a real SQL db for unit tests to minimize this risk.
 
 ## Decision
 

--- a/src/Audacia.Seed.EntityFrameworkCore/Extensions/DbContextExtensions.cs
+++ b/src/Audacia.Seed.EntityFrameworkCore/Extensions/DbContextExtensions.cs
@@ -726,6 +726,7 @@ public static class DbContextExtensions
         ArgumentNullException.ThrowIfNull(seed);
 
         var repository = new EntityFrameworkCoreSeedableRepository(context);
+        context.ChangeTracker.Clear();
         var entities = repository.SeedMany(amountToCreate, seed).ToList();
         repository.Save();
         return entities;

--- a/src/Audacia.Seed.EntityFrameworkCore/Repositories/EntityFrameworkCoreSeedableRepository.cs
+++ b/src/Audacia.Seed.EntityFrameworkCore/Repositories/EntityFrameworkCoreSeedableRepository.cs
@@ -140,6 +140,7 @@ public class EntityFrameworkCoreSeedableRepository : ISeedableRepository
         where T : class
     {
         ArgumentNullException.ThrowIfNull(seed);
+        _context.ChangeTracker.Clear();
 
         var entity = Seed(seed);
 
@@ -175,6 +176,7 @@ public class EntityFrameworkCoreSeedableRepository : ISeedableRepository
     {
         ArgumentNullException.ThrowIfNull(seed1);
         ArgumentNullException.ThrowIfNull(seed2);
+        _context.ChangeTracker.Clear();
 
         var entity1 = Seed(seed1);
         var entity2 = Seed(seed2);
@@ -215,6 +217,7 @@ public class EntityFrameworkCoreSeedableRepository : ISeedableRepository
         ArgumentNullException.ThrowIfNull(seed1);
         ArgumentNullException.ThrowIfNull(seed2);
         ArgumentNullException.ThrowIfNull(seed3);
+        _context.ChangeTracker.Clear();
 
         var entity1 = Seed(seed1);
         var entity2 = Seed(seed2);
@@ -261,6 +264,7 @@ public class EntityFrameworkCoreSeedableRepository : ISeedableRepository
         ArgumentNullException.ThrowIfNull(seed2);
         ArgumentNullException.ThrowIfNull(seed3);
         ArgumentNullException.ThrowIfNull(seed4);
+        _context.ChangeTracker.Clear();
 
         var entity1 = Seed(seed1);
         var entity2 = Seed(seed2);
@@ -312,6 +316,7 @@ public class EntityFrameworkCoreSeedableRepository : ISeedableRepository
         ArgumentNullException.ThrowIfNull(seed3);
         ArgumentNullException.ThrowIfNull(seed4);
         ArgumentNullException.ThrowIfNull(seed5);
+        _context.ChangeTracker.Clear();
 
         var entity1 = Seed(seed1);
         var entity2 = Seed(seed2);
@@ -367,6 +372,7 @@ public class EntityFrameworkCoreSeedableRepository : ISeedableRepository
         ArgumentNullException.ThrowIfNull(seed3);
         ArgumentNullException.ThrowIfNull(seed4);
         ArgumentNullException.ThrowIfNull(seed6);
+        _context.ChangeTracker.Clear();
 
         var entity1 = Seed(seed1);
         var entity2 = Seed(seed2);
@@ -427,6 +433,7 @@ public class EntityFrameworkCoreSeedableRepository : ISeedableRepository
         ArgumentNullException.ThrowIfNull(seed4);
         ArgumentNullException.ThrowIfNull(seed6);
         ArgumentNullException.ThrowIfNull(seed7);
+        _context.ChangeTracker.Clear();
 
         var entity1 = Seed(seed1);
         var entity2 = Seed(seed2);
@@ -492,6 +499,7 @@ public class EntityFrameworkCoreSeedableRepository : ISeedableRepository
         ArgumentNullException.ThrowIfNull(seed6);
         ArgumentNullException.ThrowIfNull(seed7);
         ArgumentNullException.ThrowIfNull(seed8);
+        _context.ChangeTracker.Clear();
 
         var entity1 = Seed(seed1);
         var entity2 = Seed(seed2);

--- a/src/Audacia.Seed/Audacia.Seed.csproj
+++ b/src/Audacia.Seed/Audacia.Seed.csproj
@@ -19,15 +19,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="..\..\CHANGELOG.md">
-          <Link>CHANGELOG.md</Link>
-        </Content>
-        <Content Include="..\..\README.md">
-            <Link>README.md</Link>
-        </Content>
-    </ItemGroup>
-
-    <ItemGroup>
         <None Include="..\..\audacia-logo-circle-blue.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 

--- a/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
+++ b/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
@@ -668,9 +668,8 @@ public sealed class EntitySeedExtensionTests : IDisposable
         // This asks for a new member to be set up regardless
         var seed = new BookingSeed().WithNew(b => b.Member);
 
-        var seededEntity = _context.Seed(seed);
+        var booking = _context.Seed(seed);
 
-        var booking = _context.Set<Booking>().Single(b => b.Id == seededEntity.Id);
         booking.MemberId.Should().NotBe(existingMember.Id, "we should ignore entities in the change tracker when using WithNew");
     }
 

--- a/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
+++ b/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
@@ -637,7 +637,7 @@ public sealed class EntitySeedExtensionTests : IDisposable
     }
 
     [Fact]
-    public void WithNew_ParentAlreadyInChangeTrackerWhenSeedingMany_SeedsNewGrandparent()
+    public void WithNew_ParentAlreadyInChangeTrackerWhenSeedingMany_SeedsNewParent()
     {
         // This adds a Member because it's a required parent
         _context.Seed<Booking>();
@@ -659,7 +659,7 @@ public sealed class EntitySeedExtensionTests : IDisposable
     }
 
     [Fact]
-    public void WithNew_ParentAlreadyInChangeTracker_SeedsNewGrandparent()
+    public void WithNew_ParentAlreadyInChangeTracker_SeedsNewParent()
     {
         // This adds a Member because it's a required parent
         _context.Seed<Booking>();

--- a/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
+++ b/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
@@ -636,7 +636,6 @@ public sealed class EntitySeedExtensionTests : IDisposable
             "we should be able to seed grandparents as a prerequisite");
     }
 
-
     [Fact]
     public void WithNew_ParentAlreadyInChangeTrackerWhenSeedingMany_SeedsNewGrandparent()
     {
@@ -658,7 +657,6 @@ public sealed class EntitySeedExtensionTests : IDisposable
                 "each new booking should have the same new member");
         }
     }
-
 
     [Fact]
     public void WithNew_ParentAlreadyInChangeTracker_SeedsNewGrandparent()

--- a/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
+++ b/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
@@ -636,6 +636,60 @@ public sealed class EntitySeedExtensionTests : IDisposable
             "we should be able to seed grandparents as a prerequisite");
     }
 
+
+    [Fact]
+    public void WithNew_ParentAlreadyInChangeTrackerWhenSeedingMany_SeedsNewGrandparent()
+    {
+        // This adds a Member because it's a required parent
+        _context.Seed<Booking>();
+        // This pulls a Member into the change tracker
+        var existingMember = _context.Set<Member>().Single();
+        // This asks for a new member to be set up regardless
+        var seed = new BookingSeed().WithNew(b => b.Member);
+
+        var bookings = _context.SeedMany(2, seed).ToList();
+
+        using (new AssertionScope())
+        {
+            bookings.All(b => b.MemberId != existingMember.Id).Should().BeTrue(
+                "we should ignore things in the change tracker when using WithNew and seeding many entities");
+            bookings.Select(b => b.MemberId).Distinct().Should().HaveCount(
+                1,
+                "each new booking should have the same new member");
+        }
+    }
+
+
+    [Fact]
+    public void WithNew_ParentAlreadyInChangeTracker_SeedsNewGrandparent()
+    {
+        // This adds a Member because it's a required parent
+        _context.Seed<Booking>();
+        // This pulls a Member into the change tracker
+        var existingMember = _context.Set<Member>().Single();
+        // This asks for a new member to be set up regardless
+        var seed = new BookingSeed().WithNew(b => b.Member);
+
+        var seededEntity = _context.Seed(seed);
+
+        var booking = _context.Set<Booking>().Single(b => b.Id == seededEntity.Id);
+        booking.MemberId.Should().NotBe(existingMember.Id, "we should ignore things in the change tracker when using WithNew");
+    }
+
+    [Fact]
+    public void WithNew_GrandparentAlreadyInChangeTracker_SeedsNewGrandparent()
+    {
+        _context.Seed<Booking>();
+        var existingGroup = _context.Set<MembershipGroup>().Single();
+        var seed = new EntitySeed<Booking>()
+            .WithNew(b => b.Member.MembershipGroup);
+
+        var seededEntity = _context.Seed(seed);
+
+        var booking = _context.Set<Booking>().Include(b => b.Member).Single(b => b.Id == seededEntity.Id);
+        booking.Member.MembershipGroupId.Should().NotBe(existingGroup.Id, "we should ignore things in the change tracker when using WithNew");
+    }
+
     [Fact]
     public void WithNew_FewerValuesProvidedThanWeWantToSeed_ThrowsException()
     {

--- a/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
+++ b/tests/Audacia.Seed.Tests/Customisations/EntitySeedExtensionTests.cs
@@ -651,7 +651,7 @@ public sealed class EntitySeedExtensionTests : IDisposable
         using (new AssertionScope())
         {
             bookings.All(b => b.MemberId != existingMember.Id).Should().BeTrue(
-                "we should ignore things in the change tracker when using WithNew and seeding many entities");
+                "we should ignore entities in the change tracker when using WithNew and seeding many entities");
             bookings.Select(b => b.MemberId).Distinct().Should().HaveCount(
                 1,
                 "each new booking should have the same new member");
@@ -671,7 +671,7 @@ public sealed class EntitySeedExtensionTests : IDisposable
         var seededEntity = _context.Seed(seed);
 
         var booking = _context.Set<Booking>().Single(b => b.Id == seededEntity.Id);
-        booking.MemberId.Should().NotBe(existingMember.Id, "we should ignore things in the change tracker when using WithNew");
+        booking.MemberId.Should().NotBe(existingMember.Id, "we should ignore entities in the change tracker when using WithNew");
     }
 
     [Fact]
@@ -685,7 +685,7 @@ public sealed class EntitySeedExtensionTests : IDisposable
         var seededEntity = _context.Seed(seed);
 
         var booking = _context.Set<Booking>().Include(b => b.Member).Single(b => b.Id == seededEntity.Id);
-        booking.Member.MembershipGroupId.Should().NotBe(existingGroup.Id, "we should ignore things in the change tracker when using WithNew");
+        booking.Member.MembershipGroupId.Should().NotBe(existingGroup.Id, "we should ignore entities in the change tracker when using WithNew");
     }
 
     [Fact]


### PR DESCRIPTION
### Version changed and CHANGELOG updated
- ✔ New version set in the project file(s) `.csproj` or `Directory.Build.props` and version documented in the CHANGELOG

### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ✔ Tests added/updated for all new and modified code

### README or other documentation updated
- ❎ Changes do not require documentation

### Dependency licenses
- ❎ No new/upgraded dependencies